### PR TITLE
chore: extract token to config

### DIFF
--- a/brd-ios/.gitignore
+++ b/brd-ios/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## XCode env configuration
+.env
+
 ## Build generated
 build/
 DerivedData/

--- a/brd-ios/breadwallet.xcodeproj/project.pbxproj
+++ b/brd-ios/breadwallet.xcodeproj/project.pbxproj
@@ -928,6 +928,7 @@
 		7CF5319C231EE01300E61F12 /* Base32.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Base32.swift; path = src/Utilities/Base32.swift; sourceTree = "<group>"; };
 		7CF913BD1FFC7DC30085CB70 /* TxMemoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TxMemoCell.swift; path = src/Views/TransactionCells/TxMemoCell.swift; sourceTree = "<group>"; };
 		7CF9988C23202C75004AEC17 /* BRAPIClient+Experiments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "BRAPIClient+Experiments.swift"; path = "src/Platform/BRAPIClient+Experiments.swift"; sourceTree = "<group>"; };
+		7E09EA4027D60D2100B0268C /* testnet.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = testnet.xcconfig; sourceTree = "<group>"; };
 		9A39B1222202AA3400E5018B /* HomeScreenCellHighlightView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeScreenCellHighlightView.swift; path = src/Views/AnimatedIcons/HomeScreenCellHighlightView.swift; sourceTree = "<group>"; };
 		9A39B1242202AE9E00E5018B /* MultiframeAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MultiframeAnimation.swift; path = src/Views/AnimatedIcons/MultiframeAnimation.swift; sourceTree = "<group>"; };
 		9A926EEE22034B2E00CC2263 /* CellHighlight-29.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "CellHighlight-29.png"; path = "src/Views/AnimatedIcons/Cell Highlight View Frames/CellHighlight-29.png"; sourceTree = "<group>"; };
@@ -1691,6 +1692,7 @@
 		75A2A7871DA5934300A983D8 = {
 			isa = PBXGroup;
 			children = (
+				7E09EA4027D60D2100B0268C /* testnet.xcconfig */,
 				75A2A7921DA5934300A983D8 /* breadwallet */,
 				75A2A7A71DA5934300A983D8 /* breadwalletTests */,
 				75A2A7B21DA5934300A983D8 /* breadwalletUITests */,
@@ -3159,7 +3161,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Confirm homebrew root for M1 machines\nif test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\nexport PATH\n\nif which swiftlint >/dev/null; then\n    swiftlint\nelse\n    if [ \"${CONFIGURATION}\" == \"Release\" ]; then\n        exit 0;\n    else\n        echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint or install via homebrew\"\n        exit 1\n    fi\nfi\n";
+			shellScript = "# Confirm homebrew root for M1 machines\nif test -d \"/opt/homebrew/bin/\"; then\n PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  if [ \"${CONFIGURATION}\" == \"Release\" ]; then\n    exit 0;\n  else\n    echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint or install via homebrew\"\n    exit 1\n  fi\nfi\n";
 		};
 		7CDC6A5521125C14004AE68E /* Thin Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -5680,6 +5682,7 @@
 		};
 		CEA7E69C1F0AAA84001F8C27 /* Debug-Testnet */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7E09EA4027D60D2100B0268C /* testnet.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APP_GROUPS_ID = com.fabriik.one.testnetQA;

--- a/brd-ios/breadwallet/Info.plist
+++ b/brd-ios/breadwallet/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>API_TOKEN</key>
+	<string>$(API_TOKEN)</string>
 	<key>APP_GROUPS_ID</key>
 	<string>group.${APP_GROUPS_ID}</string>
 	<key>CFBundleDevelopmentRegion</key>
@@ -117,6 +119,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/brd-ios/breadwallet/src/ApplicationController.swift
+++ b/brd-ios/breadwallet/src/ApplicationController.swift
@@ -175,7 +175,7 @@ class ApplicationController: Subscriber, Trackable {
                 guard let weakSelf = self else { return }
                 weakSelf.setWalletInfo(account: account)
                 weakSelf.coreSystem.create(account: account,
-                                           authToken: UserDefaults.apiToken,
+                                           authToken: E.apiToken,
                                            btcWalletCreationCallback: weakSelf.handleDeferedLaunchURL) {
                     weakSelf.modalPresenter = ModalPresenter(keyStore: weakSelf.keyStore,
                                                              system: weakSelf.coreSystem,

--- a/brd-ios/breadwallet/src/Environment.swift
+++ b/brd-ios/breadwallet/src/Environment.swift
@@ -117,9 +117,11 @@ struct E {
         return String(os.majorVersion) + "." + String(os.minorVersion) + "." + String(os.patchVersion)
     }()
     
-    static let apiToken: String = {
-        // TODO: diff tokens for diff envs?
-        return "ncs9v286v1063f28jcgvgle860k3i1hn2gem85v"
-    }()
+    static var apiToken: String? {
+        guard let token = Bundle.main.object(forInfoDictionaryKey: "API_TOKEN") as? String else {
+            return nil
+        }
+        return token
+    }
     
 }

--- a/brd-ios/breadwallet/src/Platform/BRReplicatedKVStore.swift
+++ b/brd-ios/breadwallet/src/Platform/BRReplicatedKVStore.swift
@@ -458,7 +458,7 @@ open class BRReplicatedKVStore: NSObject {
         // 3. for keys that we do have, sync em
         // 4. for keys that they don't have that we do, upload em
         if syncRunning {
-            DispatchQueue.main.async(execute: { 
+            DispatchQueue.main.async(execute: {
                 completionHandler(.alreadyReplicating)
             })
             return
@@ -635,7 +635,7 @@ open class BRReplicatedKVStore: NSObject {
                     })
                 } else {
                     log("Local key \(key) is newer remoteVer=\(remoteVer), updating remotely...")
-                    // if the remote version is zero it means it doesnt yet exist on the server. set the remote version 
+                    // if the remote version is zero it means it doesnt yet exist on the server. set the remote version
                     // to "1" to create the key on the server
                     let useRemoteVer = remoteVer == 0 || remoteVer < recordedRemoteVersion ? 1 : remoteVer
                     self.remote.put(key, value: localValue, version: useRemoteVer,

--- a/brd-ios/breadwallet/src/Wallet/WalletInitializer.swift
+++ b/brd-ios/breadwallet/src/Wallet/WalletInitializer.swift
@@ -1,4 +1,4 @@
-// 
+//
 //  WalletInitializer.swift
 //  breadwallet
 //
@@ -17,10 +17,10 @@ extension CoreSystem {
         system.accountInitialize(system.account, onNetwork: network, createIfDoesNotExist: create) { (res: Result<Data, System.AccountInitializationError>) in
             var serializationData: Data?
             switch res {
-            case .success (let data):
+            case .success(let data):
                 print("[SYS] system : success : \(data)")
                 serializationData = data
-            case .failure (let error):
+            case .failure(let error):
                 switch error {
                 case .alreadyInitialized:
                     print("[SYS] system : Already Initialized")

--- a/brd-ios/testnet.xcconfig
+++ b/brd-ios/testnet.xcconfig
@@ -1,0 +1,12 @@
+// 
+//  testnet.xcconfig
+//  breadwallet
+//
+//  Created by Rok on 07/03/2022.
+//  Copyright © 2022 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974

--- a/brd-ios/testnet.xcconfig
+++ b/brd-ios/testnet.xcconfig
@@ -10,3 +10,4 @@
 
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
+#include ".env"


### PR DESCRIPTION
requires an .env file to exist inside SRCROOT directory which included the required token (is part of gitignore, so each dev has to create one)